### PR TITLE
patch to rails5

### DIFF
--- a/correios_api.gemspec
+++ b/correios_api.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 	spec.add_dependency "recursive-open-struct"
 	spec.add_dependency "active_data"
 
-	spec.add_dependency 'net-http-persistent'
+	spec.add_dependency 'net-http-persistent', '~> 2.9.4'
   spec.add_dependency 'rack'
   spec.add_dependency 'savon'
 

--- a/correios_api.gemspec
+++ b/correios_api.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |spec|
 	spec.add_dependency "recursive-open-struct"
 	spec.add_dependency "active_data"
 
-	spec.add_dependency 'net-http-persistent', '~> 2.9.4'
-  spec.add_dependency 'rack', '~> 1.6', '>= 1.6.4'
-  spec.add_dependency 'savon', '~> 2.0'
+	spec.add_dependency 'net-http-persistent'
+  spec.add_dependency 'rack'
+  spec.add_dependency 'savon'
 
   spec.add_dependency 'coveralls'
   spec.add_dependency 'simplecov', '~> 0.9'

--- a/correios_api.gemspec
+++ b/correios_api.gemspec
@@ -23,12 +23,11 @@ Gem::Specification.new do |spec|
 	spec.add_dependency "active_data"
 
 	spec.add_dependency 'net-http-persistent', '~> 2.9.4'
-  spec.add_dependency 'rack'
-  spec.add_dependency 'savon'
-
-  spec.add_dependency 'coveralls'
-  spec.add_dependency 'simplecov', '~> 0.9'
-  spec.add_dependency 'webmock', '~> 1.0'
+	spec.add_dependency 'rack', '~> 2.0.1'
+	spec.add_dependency 'savon', '~> 2.11.1'
+	spec.add_dependency 'coveralls'
+	spec.add_dependency 'simplecov', '~> 0.9'
+	spec.add_dependency 'webmock', '~> 1.0'
 
 	spec.add_development_dependency "bundler"
 	spec.add_development_dependency "rake"


### PR DESCRIPTION
To make compatible with Rails 5.0.0 i bumped some gems dependences:
gem 'net-http-persistent', '~> 2.9.4'
gem 'rack', '~> 2.0.1'
gem 'savon', '~> 2.11.1'

So there is a new version of net-http-persistent avaiable (3.0) but there is a majors changes that makes it incompatible with lot of others gems. 

So I've tested all the way from "solicita_etiquetas" to "solicita_xml_plp" it worked nice.